### PR TITLE
Handle null responses in case of TPS throttling

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ You can see available options via the `--help` flag.
   $GOPATH/bin/github-analyzer \
     --organization crashappsec \
     --token "$GH_SECURITY_AUDITOR_TOKEN" \
-    --enableStats
   ```
 
 ### Running using Docker
@@ -121,7 +120,6 @@ You can see available options via the `--help` flag.
           --organization crashappsec \
           --output output \
           --token "$GH_SECURITY_AUDITOR_TOKEN" \
-          --enableStats
   ```
 
 ## Permissions
@@ -147,7 +145,7 @@ needed. Example usage:
 github-analyzer \
     --organization crashappsec \
     --token "$GH_SECURITY_AUDITOR_TOKEN" \
-    --enableStats \
+    --userPermissionStats \
     --enableScraping \
     --username "$GH_SECURITY_AUDITOR_USERNAME" \
     --password "$GH_SECURITY_AUDITOR_PASSWORD" \

--- a/cmd/github-analyzer/main.go
+++ b/cmd/github-analyzer/main.go
@@ -51,8 +51,7 @@ func runCmd() {
 			config.ViperEnv.Username,
 			config.ViperEnv.Password,
 			config.ViperEnv.OtpSeed,
-			config.ViperEnv.Organization,
-			config.ViperEnv.EnableStats)
+			config.ViperEnv.Organization)
 		if err != nil {
 			log.Logger.Error(err)
 		}
@@ -68,7 +67,7 @@ func runCmd() {
 			log.Logger.Error(err)
 			return
 		}
-		results, execStatus, err := auditor.AuditOrg(config.ViperEnv.Organization, config.ViperEnv.EnableStats)
+		results, execStatus, err := auditor.AuditOrg(config.ViperEnv.Organization, config.ViperEnv.UserPermissionStats)
 		if err != nil {
 			log.Logger.Error(err)
 		}
@@ -172,7 +171,7 @@ func NewRootCommand() *cobra.Command {
 	rootCmd.Flags().
 		BoolVarP(&config.ViperEnv.Version, "version", "", false, "print version and exit")
 	rootCmd.Flags().
-		BoolVarP(&config.ViperEnv.EnableStats, "enableStats", "", false, "enable user permission statistics (might be slow due to throttling limits)")
+		BoolVarP(&config.ViperEnv.UserPermissionStats, "userPermissionStats", "", false, "enable user permission statistics (might be slow in large orgs due to throttling limits)")
 
 	rootCmd.Flags().
 		BoolVarP(&config.ViperEnv.EnableScraping, "enableScraping", "", false, "enable experimental checks that rely on screen scraping")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,18 +7,18 @@ const (
 )
 
 type ViperEnvVars struct {
-	CfgFile        string `mapstructure:"CFG_FILE"`
-	EnableScraping bool   `mapstructure:"ENABLE_SCRAPING"`
-	EnableStats    bool   `mapstructure:"ENABLE_STATS"`
-	Version        bool   `mapstructure:"VERSION"`
-	Organization   string `mapstructure:"ORGANIZATION"`
-	OtpSeed        string `mapstructure:"OTP_SEED"`
-	OutputDir      string `mapstructure:"OUTPUT_DIR"`
-	Password       string `mapstructure:"PASSWORD"`
-	Port           int    `mapstructure:"PORT"`
-	ScmURL         string `mapstructure:"SCM_URL"`
-	Token          string `mapstructure:"TOKEN"`
-	Username       string `mapstructure:"USERNAME"`
+	CfgFile             string `mapstructure:"CFG_FILE"`
+	EnableScraping      bool   `mapstructure:"ENABLE_SCRAPING"`
+	UserPermissionStats bool   `mapstructure:"USER_PERMISSION_STATS"`
+	Version             bool   `mapstructure:"VERSION"`
+	Organization        string `mapstructure:"ORGANIZATION"`
+	OtpSeed             string `mapstructure:"OTP_SEED"`
+	OutputDir           string `mapstructure:"OUTPUT_DIR"`
+	Password            string `mapstructure:"PASSWORD"`
+	Port                int    `mapstructure:"PORT"`
+	ScmURL              string `mapstructure:"SCM_URL"`
+	Token               string `mapstructure:"TOKEN"`
+	Username            string `mapstructure:"USERNAME"`
 }
 
 var ViperEnv ViperEnvVars

--- a/pkg/github/auditor/auditor.go
+++ b/pkg/github/auditor/auditor.go
@@ -54,7 +54,7 @@ func (gs GithubAuditor) AuditOrg(
 	ctx := context.Background()
 	back := &backoff.Backoff{
 		Min:    30 * time.Second,
-		Max:    10 * time.Minute,
+		Max:    30 * time.Minute,
 		Jitter: true,
 	}
 	org, err := org.NewOrganization(ctx, gs.client, back, name)

--- a/pkg/github/auditor/auditor.go
+++ b/pkg/github/auditor/auditor.go
@@ -49,7 +49,7 @@ func NewGithubAuditor(token string) (*GithubAuditor, error) {
 // or yielded in an error), and a generic overall error if audit fails overall
 func (gs GithubAuditor) AuditOrg(
 	name string,
-	enableStats bool,
+	enableUserPermissionStats bool,
 ) ([]issue.Issue, map[issue.IssueID]error, error) {
 	ctx := context.Background()
 	back := &backoff.Backoff{
@@ -63,5 +63,5 @@ func (gs GithubAuditor) AuditOrg(
 		return nil, nil, err
 	}
 
-	return org.Audit(ctx, enableStats)
+	return org.Audit(ctx, enableUserPermissionStats)
 }

--- a/pkg/github/auditor/auditor.go
+++ b/pkg/github/auditor/auditor.go
@@ -53,8 +53,8 @@ func (gs GithubAuditor) AuditOrg(
 ) ([]issue.Issue, map[issue.IssueID]error, error) {
 	ctx := context.Background()
 	back := &backoff.Backoff{
-		Min:    10 * time.Second,
-		Max:    1 * time.Hour,
+		Min:    30 * time.Second,
+		Max:    10 * time.Minute,
 		Jitter: true,
 	}
 	org, err := org.NewOrganization(ctx, gs.client, back, name)

--- a/pkg/github/org/org.go
+++ b/pkg/github/org/org.go
@@ -543,6 +543,8 @@ func (org *Organization) AuditMemberPermissions(
 	var issues []issue.Issue
 	execStatus := make(map[issue.IssueID]error, 1)
 
+	log.Logger.Infof("[slow] Fetching user permissions for %s", *org.info.Login)
+
 	// userRepoPermissions holds a list of all repos with a given permission for a given user
 	type userRepoPermissions map[string]([]types.RepoName)
 	// permission summary is the list of different permissions for a user
@@ -620,7 +622,7 @@ func (org *Organization) AuditMemberPermissions(
 
 func (org *Organization) Audit(
 	ctx context.Context,
-	enableStats bool,
+	enableUserPermissionStats bool,
 ) ([]issue.Issue, map[issue.IssueID]error, error) {
 	var allIssues []issue.Issue
 	execStatus := map[issue.IssueID]error{}
@@ -634,7 +636,7 @@ func (org *Organization) Audit(
 	org.GetInstalls(ctx)
 	org.GetActionRunners(ctx)
 
-	if enableStats {
+	if enableUserPermissionStats {
 		auditHooks = append(auditHooks, org.AuditMemberPermissions)
 	}
 	for _, hook := range auditHooks {

--- a/pkg/github/repo/repo.go
+++ b/pkg/github/repo/repo.go
@@ -157,6 +157,7 @@ func (repo *Repository) GetCollaborators(ctx context.Context) (
 		log.Logger.Error(err)
 	}
 
+	repo.backoff.Reset()
 	collaborators := make(map[types.UserLogin]types.User, len(users))
 	for _, u := range users {
 		collaborators[types.UserLogin(*u.Login)] = u

--- a/pkg/github/utils/utils.go
+++ b/pkg/github/utils/utils.go
@@ -109,7 +109,7 @@ func GetPaginatedResult[T any, K any](
 	} else {
 		back = &backoff.Backoff{
 			Min:    30 * time.Second,
-			Max:    10 * time.Minute,
+			Max:    30 * time.Minute,
 			Jitter: true,
 		}
 	}
@@ -124,7 +124,7 @@ func GetPaginatedResult[T any, K any](
 			time.Sleep(d)
 			if resp == nil {
 				retries += 1
-				if retries > 5 {
+				if retries > 10 {
 					return results, fmt.Errorf(
 						"Aborting after 5 failed retries",
 					)

--- a/pkg/output/html/html.go
+++ b/pkg/output/html/html.go
@@ -342,6 +342,9 @@ func Serve(
 		"Server with HTML summary starting at 0.0.0.0:%d\n",
 		port,
 	)
+	fmt.Println(
+		"\n\n\t Analysis complete! Visit localhost:3000 using your browser to see results",
+	)
 	err = http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
 	if err != nil {
 		log.Logger.Error(err)

--- a/pkg/output/html/templates/index.html.tmpl
+++ b/pkg/output/html/templates/index.html.tmpl
@@ -102,7 +102,7 @@
       </div>
     </div>
     <div>
-      The following checks had errors - does token you used have the appropriate permissions?
+      The following checks had errors - does the token you used have the appropriate permissions?
       <ul>
         {{range $issue := $failed}}
         <li>

--- a/pkg/scraping/scraping.go
+++ b/pkg/scraping/scraping.go
@@ -12,7 +12,7 @@ import (
 )
 
 func AuditScraping(
-	username, password, otpseed, org string, enableStats bool,
+	username, password, otpseed, org string,
 ) ([]issue.Issue, map[issue.IssueID]error, error) {
 	var issues []issue.Issue
 	execStatus := make(map[issue.IssueID]error, 1)
@@ -31,10 +31,6 @@ func AuditScraping(
 	}
 	if !restrictedAccess && err == nil {
 		issues = append(issues, issue.ApplicationRestrictionsDisabled(org))
-	}
-
-	if !enableStats {
-		return issues, execStatus, nil
 	}
 
 	apps, err := client.ListOAuthApps(org)


### PR DESCRIPTION
This PR does not pass a global backoff to all clients doing pagination but tries to have them run independently as much as possible and also handles a missed case where github's response could be nil after TPS errors